### PR TITLE
change fs.readFileSync path parameter to '/bundle.js'; fixes #2

### DIFF
--- a/lib/webpackRequire.js
+++ b/lib/webpackRequire.js
@@ -44,7 +44,7 @@ function webpackRequire(config, name, cb) {
       cb(statsJson.errors, null, stats);
     }
 
-    var data = fs.readFileSync(path.join(compiler.outputPath, 'bundle.js'), 'utf8');
+    var data = fs.readFileSync('/bundle.js', 'utf8');
     var script = contextify.createScript(data);
     cb(null, function() {
       var context = contextify.createContext({});


### PR DESCRIPTION
Cool, so I'm assuming this still works on Mac/Linux?
